### PR TITLE
removing duplicate key in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,4 +52,3 @@ markdown_extensions:
       linenums: true
 plugins:
     - search
-markdown_extensions:


### PR DESCRIPTION
At least one of the markdown_extensions wasn't working correctly (I noticed the admonition "warning" on [this page](http://www.coderdojotc.org/web-ux/intro-to-html/04-bold-and-italic/))

Removing the duplicate "markdown_extensions" key seems to resolve the issue.